### PR TITLE
TRPG.NET が提供する公開サーバを追加

### DIFF
--- a/servers.yaml
+++ b/servers.yaml
@@ -3,3 +3,4 @@
 - https://bcdice.kazagakure.net
 - https://bcdice.aimsot.net
 - https://bcdice-api.raa0121.info
+- https://bcdice.trpg.net


### PR DESCRIPTION
TRPG.NET (クリエイターズネットワーク) のサービス一覧ページ
https://www.cre.ne.jp/services/dice-rollers