### PR TITLE
remove server bcdice.museru.com

### DIFF
--- a/servers.yaml
+++ b/servers.yaml
@@ -6,4 +6,3 @@
 - https://bcdice.trpg.net
 - https://bcdice.kiridaruma.net
 - https://bcdice.trpgonsen.click
-- https://bcdice.museru.com/org


### PR DESCRIPTION
近い将来、 https://bcdice.museru.com を閉鎖する予定があるため、一覧からの削除のPRをさせていただきます。
よろしくお願いします。
